### PR TITLE
Add SQLite database storage for listings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ csv = "1.3"
 futures = "0.3"
 async-trait = "0.1.84"
 rayon = "1.10.0"
+rusqlite = { version = "0.30", features = ["bundled"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use crate::models::CsvRow;
+
+pub fn init_db() -> Result<Connection> {
+    let data_dir = std::path::Path::new("data");
+    std::fs::create_dir_all(data_dir)?;
+    let db_path = data_dir.join("listings.db");
+
+    let conn = Connection::open(db_path)?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS listings (
+            id TEXT PRIMARY KEY,
+            listing_id TEXT NOT NULL,
+            street_address TEXT NOT NULL,
+            sold_at TEXT NOT NULL,
+            sold_at_label TEXT NOT NULL,
+            asking_price INTEGER,
+            final_price INTEGER,
+            living_area REAL,
+            location TEXT,
+            location_description TEXT NOT NULL,
+            fee INTEGER,
+            square_meter_price INTEGER,
+            rooms TEXT NOT NULL,
+            price_change REAL,
+            broker_agency_name TEXT NOT NULL,
+            broker_name TEXT,
+            labels TEXT NOT NULL,
+            url TEXT NOT NULL
+        )",
+        [],
+    )?;
+
+    Ok(conn)
+}
+
+pub fn save_listings_to_db(conn: &Connection, listings: &[CsvRow]) -> Result<()> {
+    if listings.is_empty() {
+        println!("No listings to save to database");
+        return Ok(());
+    }
+
+    let tx = conn.transaction()?;
+
+    for listing in listings {
+        tx.execute(
+            "INSERT OR REPLACE INTO listings (
+                id, listing_id, street_address, sold_at, sold_at_label,
+                asking_price, final_price, living_area, location,
+                location_description, fee, square_meter_price, rooms,
+                price_change, broker_agency_name, broker_name, labels, url
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params![
+                listing.id,
+                listing.listing_id,
+                listing.street_address,
+                listing.sold_at,
+                listing.sold_at_label,
+                listing.asking_price,
+                listing.final_price,
+                listing.living_area,
+                listing.location,
+                listing.location_description,
+                listing.fee,
+                listing.square_meter_price,
+                listing.rooms,
+                listing.price_change,
+                listing.broker_agency_name,
+                listing.broker_name,
+                listing.labels,
+                listing.url,
+            ],
+        )?;
+    }
+
+    tx.commit()?;
+    println!("Saved {} listings to database", listings.len());
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use futures::future::join_all;
 
 mod client;
+mod db;
 mod listing;
 mod models;
 mod storage;
@@ -58,7 +59,7 @@ async fn main() -> Result<()> {
         .flatten()
         .collect::<Vec<_>>();
 
-    storage::save_listings_to_csv(&csv_rows, "sold")?;
+    storage::save_listings(&csv_rows, "sold")?;
 
     Ok(())
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,6 +2,25 @@ use anyhow::Result;
 use chrono::Local;
 use std::{fs, io::Write, path::Path};
 
+use crate::db;
+
+pub fn save_listings<T>(listings: &[T], filename_prefix: &str) -> Result<()>
+where
+    T: serde::Serialize,
+{
+    // Initialize SQLite database
+    let conn = db::init_db()?;
+    if let Ok(csv_rows) = serde_json::to_value(listings) {
+        if let Ok(csv_rows) = serde_json::from_value(csv_rows) {
+            db::save_listings_to_db(&conn, &csv_rows)?;
+        }
+    }
+
+    // Save to CSV as well
+    save_listings_to_csv(listings, filename_prefix)?;
+    Ok(())
+}
+
 pub fn save_listings_to_csv<T>(listings: &[T], filename_prefix: &str) -> Result<()>
 where
     T: serde::Serialize,


### PR DESCRIPTION
This PR adds SQLite database support for storing listings:

- Added rusqlite dependency with bundled SQLite support
- Created new db.rs module for database operations
- Modified storage module to save listings to both SQLite and CSV
- Listings are now stored in data/listings.db for persistence and easier querying
- CSV files are still generated for compatibility and backup